### PR TITLE
feat: images may have bootsectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "anyhow"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +131,7 @@ dependencies = [
 name = "fuse-ext4-rs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ext4",
  "fuse_mt",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bootsector"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1016d648f0ce0ef68c93a733e68f0c5a7136f316e703304f424d4ac3f62a6f73"
+dependencies = [
+ "crc",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +141,7 @@ name = "fuse-ext4-rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bootsector",
  "ext4",
  "fuse_mt",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
+bootsector = "0.1"
 fuse_mt = "0.5.1"
 ext4 = "0.7.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
 fuse_mt = "0.5.1"
 ext4 = "0.7.0"
 

--- a/src/ext4fs.rs
+++ b/src/ext4fs.rs
@@ -2,8 +2,8 @@
 //
 //
 
+use std::ffi::OsString;
 use std::fs;
-use std::ffi::{OsString};
 
 use fuse_mt::*;
 
@@ -14,24 +14,22 @@ pub struct Ext4FS {
 //impl PassthroughFS {
 //}
 
-
 impl FilesystemMT for Ext4FS {
-
     //fn init(&self, _req: RequestInfo) -> ResultEmpty {
-        //println!("init");
+    //println!("init");
 
-        //let r = fs::File::open(&self.target).expect("openable file");
-        //let mut options = ext4::Options::default();
-        //options.checksums = ext4::Checksums::Enabled;
-        //let mut vol = ext4::SuperBlock::new_with_options(r, &options).expect("ext4 volume");
-        //let root = vol.root().expect("root");
-        //vol.walk(&root, "/", &mut |_, path, _, _| {
-            //println!("{}", path);
-            //Ok(true)
-        //})
-        //.expect("walk");
+    //let r = fs::File::open(&self.target).expect("openable file");
+    //let mut options = ext4::Options::default();
+    //options.checksums = ext4::Checksums::Enabled;
+    //let mut vol = ext4::SuperBlock::new_with_options(r, &options).expect("ext4 volume");
+    //let root = vol.root().expect("root");
+    //vol.walk(&root, "/", &mut |_, path, _, _| {
+    //println!("{}", path);
+    //Ok(true)
+    //})
+    //.expect("walk");
 
-        //Ok(())
+    //Ok(())
     //}
 
     fn init(&self, _req: RequestInfo) -> ResultEmpty {
@@ -41,7 +39,6 @@ impl FilesystemMT for Ext4FS {
         let mut superblock = ext4::SuperBlock::new(&mut block_device).unwrap();
         let target_inode_number = superblock.resolve_path("/").unwrap().inode;
         println!("{}", target_inode_number);
-
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,32 @@
-extern crate ext4;
-
 use std::env;
 use std::ffi::{OsStr, OsString};
+
+use anyhow::Result;
 
 mod ext4fs;
 
 //fn main() {
-    //let r = fs::File::open(env::args().nth(1).expect("one argument")).expect("openable file");
-    //let mut options = ext4::Options::default();
-    //options.checksums = ext4::Checksums::Enabled;
-    //let mut vol = ext4::SuperBlock::new_with_options(r, &options).expect("ext4 volume");
-    //let root = vol.root().expect("root");
-    //vol.walk(&root, "/", &mut |_, path, _, _| {
-        //println!("{}", path);
-        //Ok(true)
-    //})
-    //.expect("walk");
+//let r = fs::File::open(env::args().nth(1).expect("one argument")).expect("openable file");
+//let mut options = ext4::Options::default();
+//options.checksums = ext4::Checksums::Enabled;
+//let mut vol = ext4::SuperBlock::new_with_options(r, &options).expect("ext4 volume");
+//let root = vol.root().expect("root");
+//vol.walk(&root, "/", &mut |_, path, _, _| {
+//println!("{}", path);
+//Ok(true)
+//})
+//.expect("walk");
 //}
 
-
-fn main() {
+fn start() -> Result<i32> {
     let args: Vec<OsString> = env::args_os().collect();
 
     if args.len() != 3 {
-        println!("usage: {} <target> <mountpoint>", &env::args().next().unwrap());
-        ::std::process::exit(-1);
+        println!(
+            "usage: {} <target> <mountpoint>",
+            &env::args().next().unwrap()
+        );
+        return Ok(2);
     }
 
     let filesystem = ext4fs::Ext4FS {
@@ -33,5 +35,11 @@ fn main() {
 
     let fuse_args: Vec<&OsStr> = vec![&OsStr::new("-o"), &OsStr::new("auto_unmount")];
 
-    fuse_mt::mount(fuse_mt::FuseMT::new(filesystem, 1), &args[2], &fuse_args).unwrap();
+    fuse_mt::mount(fuse_mt::FuseMT::new(filesystem, 1), &args[2], &fuse_args)?;
+
+    Ok(0)
+}
+
+fn main() -> Result<()> {
+    ::std::process::exit(start()?)
 }


### PR DESCRIPTION
The reference images have partition tables and boot sectors, they aren't just bare block devices. Use the excellent `bootsector` crate to unpack them.

The error handling here is garbage because of limitations from the library. We need to do more work outside.

Or not support this.