### PR TITLE
feat: absolutely minimal directory listing, fixing test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cntr-fuse-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3892895a649be4477b275deeca4a4f5e64f31c7986eb3dab81d6cfa88491a"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +101,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bootsector",
+ "cntr-fuse-sys",
  "ext4",
  "fuse_mt",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ libc = "0.2"
 time = "0.1"
 
 [dev-dependencies]
+cntr-fuse-sys = "0.4.0"
 nix = "0.19"

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,9 +1,12 @@
+use std::convert::TryFrom;
+use std::ffi::OsString;
+use std::ffi::{CString, OsStr};
 use std::fs;
 use std::path::Path;
 use std::thread;
+use std::time::Duration;
 
 use anyhow::Result;
-use std::time::Duration;
 
 #[test]
 fn smoke() -> Result<()> {
@@ -13,10 +16,11 @@ fn smoke() -> Result<()> {
         fuse_ext4_rs::mount_and_run("tests/all-types-tiny.img".as_ref(), dest.as_ref())
     });
     thread::sleep(Duration::from_millis(500));
-    let unmount_result = nix::mount::umount(dest);
-    println!("{:?}", unmount_result);
+    unsafe {
+        let cstr = CString::new(dest).expect("static string");
+        cntr_fuse_sys::fuse_unmount_compat22(cstr.as_ptr())
+    }
     thread.join().unwrap()?;
-    unmount_result?;
 
     Ok(())
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -8,9 +8,6 @@ use std::time::Duration;
 #[test]
 fn smoke() -> Result<()> {
     let dest = "mnt";
-    std::process::Command::new("pkill")
-        .args(&["-f", "gvfs"])
-        .status()?;
     fs::create_dir_all(dest)?;
     let thread = thread::spawn(move || {
         fuse_ext4_rs::mount_and_run("tests/all-types-tiny.img".as_ref(), dest.as_ref())


### PR DESCRIPTION
Adding directory listing for just `/`, as empty (should probably have `.` and `..`), and some basic metadata, means we don't reeally need to kill gvfs anymore, even though it was fun.

Apparently umount always fails, and you have to call the fuse variant. Dunno why the library doesn't expose this. Couldn't get the lifetimes to work with their `spawn_mount`.

https://github.com/zargony/fuse-rs/blob/39fde4a5c47ce370d228ac190f950bd835db7f47/src/channel.rs#L135-L148

Follows #3.