### PR TITLE
feat: update ext4: no more mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 
 [[package]]
 name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
+
+[[package]]
+name = "byteorder"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
@@ -71,14 +77,15 @@ dependencies = [
 
 [[package]]
 name = "ext4"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ccec9177b671bbef2f7d2e8e6f071886fd7f48a3a2077e296e293d22c3cae"
+checksum = "60266253e9902a2bad0da1aaf708d5549a5dffed23ffdd8c6a56446999ff21cc"
 dependencies = [
  "anyhow",
  "bitflags",
- "byteorder",
+ "byteorder 1.4.2",
  "crc",
+ "positioned-io",
  "thiserror",
 ]
 
@@ -106,6 +113,7 @@ dependencies = [
  "fuse_mt",
  "libc",
  "nix",
+ "positioned-io",
  "time",
 ]
 
@@ -129,6 +137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
@@ -182,6 +200,18 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "positioned-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c405a565f48a728dbb07fa1770e30791b0fa3e6344c1e5615225ce84049354d6"
+dependencies = [
+ "byteorder 0.5.3",
+ "kernel32-sys",
+ "libc",
+ "winapi 0.2.8",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -255,7 +285,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -272,6 +302,12 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -279,6 +315,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ edition = "2018"
 anyhow = "1"
 bootsector = "0.1"
 fuse_mt = "0.5.1"
-ext4 = "0.8"
+ext4 = "0.9"
 libc = "0.2"
+positioned-io = "0.2"
 time = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
The new release of ext4-rs drops the requirement for &mut self everywhere, so we no longer need our Mutex. Still need the ugly wrapper trait, and they have failed to provide a blanket implementation for Box, unfortunately.