### PR TITLE
feat: something about owls

### DIFF
--- a/src/block_device.rs
+++ b/src/block_device.rs
@@ -1,0 +1,42 @@
+use std::ffi::OsStr;
+use std::io;
+
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use positioned_io::ReadAt;
+
+pub trait BlockDevice: ReadAt + Send + Sync {}
+impl<T: ReadAt + Send + Sync> BlockDevice for T {}
+
+pub fn open_raw_or_first_partition<S: AsRef<OsStr>>(target: S) -> Result<Box<dyn BlockDevice>> {
+    let mut block_device = std::fs::File::open(target.as_ref()).unwrap();
+
+    let partitions =
+        match bootsector::list_partitions(&mut block_device, &bootsector::Options::default()) {
+            Ok(parts) => parts,
+            Err(e) if io::ErrorKind::NotFound == e.kind() => vec![],
+            Err(e) => Err(e).with_context(|| anyhow!("searching for partitions"))?,
+        };
+
+    let block_device: Box<dyn BlockDevice> = if partitions.len() == 0 {
+        Box::new(block_device)
+    } else {
+        let part = partitions
+            .get(0)
+            .ok_or_else(|| anyhow!("there wasn't at least one partition"))?;
+        Box::new(positioned_io::Slice::new(
+            block_device,
+            part.first_byte,
+            Some(part.len),
+        ))
+    };
+
+    Ok(block_device)
+}
+
+impl ReadAt for Box<dyn BlockDevice> {
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+        (**self).read_at(pos, buf)
+    }
+}

--- a/src/ext4fs.rs
+++ b/src/ext4fs.rs
@@ -3,6 +3,7 @@
 //
 
 use std::convert::TryFrom;
+use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::io;
 use std::path::Path;
@@ -13,6 +14,7 @@ use ext4::Enhanced;
 use ext4::FileType as ExtFileType;
 use fuse_mt::*;
 use positioned_io::ReadAt;
+use time::Timespec;
 
 pub trait BlockDevice: ReadAt + Send + Sync {}
 impl<T: ReadAt + Send + Sync> BlockDevice for T {}
@@ -67,6 +69,8 @@ impl FilesystemMT for Ext4FS {
         Ok(())
     }
 
+    fn destroy(&self, _req: RequestInfo) {}
+
     fn getattr(&self, _req: RequestInfo, path: &Path, _fh: Option<u64>) -> ResultEntry {
         println!("{:?}", path);
         if path != Path::new("/") {
@@ -90,6 +94,161 @@ impl FilesystemMT for Ext4FS {
                 flags: 0,
             },
         ))
+    }
+
+    fn chmod(&self, _req: RequestInfo, _path: &Path, _fh: Option<u64>, _mode: u32) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn chown(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: Option<u64>,
+        _uid: Option<u32>,
+        _gid: Option<u32>,
+    ) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn truncate(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: Option<u64>,
+        _size: u64,
+    ) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn utimens(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: Option<u64>,
+        _atime: Option<Timespec>,
+        _mtime: Option<Timespec>,
+    ) -> ResultEmpty {
+        Err(libc::ENOSYS)
+    }
+
+    fn utimens_macos(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: Option<u64>,
+        _crtime: Option<Timespec>,
+        _chgtime: Option<Timespec>,
+        _bkuptime: Option<Timespec>,
+        _flags: Option<u32>,
+    ) -> ResultEmpty {
+        Err(libc::ENOSYS)
+    }
+
+    fn readlink(&self, _req: RequestInfo, _path: &Path) -> ResultData {
+        Err(libc::ENOSYS)
+    }
+
+    fn mknod(
+        &self,
+        _req: RequestInfo,
+        _parent: &Path,
+        _name: &OsStr,
+        _mode: u32,
+        _rdev: u32,
+    ) -> ResultEntry {
+        Err(libc::EROFS)
+    }
+
+    fn mkdir(&self, _req: RequestInfo, _parent: &Path, _name: &OsStr, _mode: u32) -> ResultEntry {
+        Err(libc::EROFS)
+    }
+
+    fn unlink(&self, _req: RequestInfo, _parent: &Path, _name: &OsStr) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn rmdir(&self, _req: RequestInfo, _parent: &Path, _name: &OsStr) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn symlink(
+        &self,
+        _req: RequestInfo,
+        _parent: &Path,
+        _name: &OsStr,
+        _target: &Path,
+    ) -> ResultEntry {
+        Err(libc::EROFS)
+    }
+
+    fn rename(
+        &self,
+        _req: RequestInfo,
+        _parent: &Path,
+        _name: &OsStr,
+        _newparent: &Path,
+        _newname: &OsStr,
+    ) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn link(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _newparent: &Path,
+        _newname: &OsStr,
+    ) -> ResultEntry {
+        Err(libc::EROFS)
+    }
+
+    fn open(&self, _req: RequestInfo, _path: &Path, _flags: u32) -> ResultOpen {
+        Err(libc::ENOSYS)
+    }
+
+    fn read(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: u64,
+        _offset: u64,
+        _size: u32,
+        callback: impl FnOnce(ResultSlice<'_>) -> CallbackResult,
+    ) -> CallbackResult {
+        callback(Err(libc::ENOSYS))
+    }
+
+    fn write(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: u64,
+        _offset: u64,
+        _data: Vec<u8>,
+        _flags: u32,
+    ) -> ResultWrite {
+        Err(libc::EROFS)
+    }
+
+    fn flush(&self, _req: RequestInfo, _path: &Path, _fh: u64, _lock_owner: u64) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn release(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: u64,
+        _flags: u32,
+        _lock_owner: u64,
+        _flush: bool,
+    ) -> ResultEmpty {
+        Err(libc::ENOSYS)
+    }
+
+    fn fsync(&self, _req: RequestInfo, _path: &Path, _fh: u64, _datasync: bool) -> ResultEmpty {
+        Err(libc::EROFS)
     }
 
     fn opendir(&self, _req: RequestInfo, path: &Path, _flags: u32) -> ResultOpen {
@@ -145,5 +304,52 @@ impl FilesystemMT for Ext4FS {
         } else {
             Err(libc::EBADF)
         }
+    }
+
+    fn fsyncdir(&self, _req: RequestInfo, _path: &Path, _fh: u64, _datasync: bool) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn statfs(&self, _req: RequestInfo, _path: &Path) -> ResultStatfs {
+        Err(libc::ENOSYS)
+    }
+
+    fn setxattr(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _name: &OsStr,
+        _value: &[u8],
+        _flags: u32,
+        _position: u32,
+    ) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn getxattr(&self, _req: RequestInfo, _path: &Path, _name: &OsStr, _size: u32) -> ResultXattr {
+        Err(libc::ENOSYS)
+    }
+
+    fn listxattr(&self, _req: RequestInfo, _path: &Path, _size: u32) -> ResultXattr {
+        Err(libc::ENOSYS)
+    }
+
+    fn removexattr(&self, _req: RequestInfo, _path: &Path, _name: &OsStr) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn access(&self, _req: RequestInfo, _path: &Path, _mask: u32) -> ResultEmpty {
+        Err(libc::ENOSYS)
+    }
+
+    fn create(
+        &self,
+        _req: RequestInfo,
+        _parent: &Path,
+        _name: &OsStr,
+        _mode: u32,
+        _flags: u32,
+    ) -> ResultCreate {
+        Err(libc::EROFS)
     }
 }

--- a/src/ext4fs.rs
+++ b/src/ext4fs.rs
@@ -206,7 +206,7 @@ impl FilesystemMT for Ext4FS {
     }
 
     fn flush(&self, _req: RequestInfo, _path: &Path, _fh: u64, _lock_owner: u64) -> ResultEmpty {
-        Err(libc::EROFS)
+        Err(libc::ENOSYS)
     }
 
     fn release(

--- a/src/fh.rs
+++ b/src/fh.rs
@@ -1,0 +1,55 @@
+//! We're actually treating inodes as filehandles, because fuse doesn't expose
+//! any filehandle stuff to us?
+
+use std::convert::TryFrom;
+use std::path::Path;
+
+use ext4::SuperBlock;
+use ext4::{Inode, ParseError};
+use positioned_io::ReadAt;
+
+fn inode_load<T: ReadAt>(fs: &SuperBlock<T>, inode: u32) -> Result<Inode, libc::c_int> {
+    match fs.load_inode(inode) {
+        Ok(inode) => Ok(inode),
+        Err(e) => {
+            eprintln!("unexpected error loading: {:?}", e);
+            Err(libc::EIO)
+        }
+    }
+}
+
+pub fn inode_from_fh_or_path<T: ReadAt>(
+    fs: &SuperBlock<T>,
+    fh: Option<u64>,
+    path: &Path,
+) -> Result<Inode, libc::c_int> {
+    match fh {
+        Some(fh) => match u32::try_from(fh) {
+            Ok(fh) => inode_load(fs, fh),
+            Err(_) => {
+                eprintln!("bad fh {:?}", fh);
+                Err(libc::EBADF)
+            }
+        },
+        None => match path.to_str() {
+            None => {
+                eprintln!("invalid utf-8 in path: {:?}", path);
+                Err(libc::EINVAL)
+            }
+            Some(path) => match fs.resolve_path(path) {
+                Err(e) => match e.downcast::<ParseError>() {
+                    Ok(ParseError::NotFound { .. }) => Err(libc::ENOENT),
+                    Ok(e) => {
+                        eprintln!("unexpected error parsing: {:?}", e);
+                        Err(libc::ENOSYS)
+                    }
+                    Err(e) => {
+                        eprintln!("unexpected error resolving: {:?}", e);
+                        Err(libc::EIO)
+                    }
+                },
+                Ok(ent) => inode_load(fs, ent.inode),
+            },
+        },
+    }
+}

--- a/src/fh.rs
+++ b/src/fh.rs
@@ -2,6 +2,10 @@
 //! any filehandle stuff to us?
 
 use std::convert::TryFrom;
+use std::io;
+use std::io::Read;
+use std::io::Seek;
+use std::io::SeekFrom;
 use std::path::Path;
 
 use ext4::SuperBlock;
@@ -52,4 +56,29 @@ pub fn inode_from_fh_or_path<T: ReadAt>(
             },
         },
     }
+}
+pub fn read_buf<T: ReadAt>(
+    fs: &SuperBlock<T>,
+    fh: u64,
+    path: &Path,
+    offset: u64,
+    size: u32,
+) -> Result<Vec<u8>, libc::c_int> {
+    let inode = inode_from_fh_or_path(fs, Some(fh), path)?;
+    let reader = fs.open(&inode).expect("TODO: open");
+
+    let mut buf = vec![0; usize::try_from(size).unwrap_or(usize::MAX)];
+    let found = read_at(reader, offset, &mut buf).map_err(|e| {
+        e.raw_os_error().unwrap_or_else(|| {
+            eprintln!("read error: {:?}", e);
+            libc::EIO
+        })
+    })?;
+    buf.resize(found, 0);
+    Ok(buf)
+}
+
+fn read_at<R: Read + Seek>(mut reader: R, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
+    reader.seek(SeekFrom::Start(offset))?;
+    reader.read(buf)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 
 mod block_device;
 mod ext4fs;
+mod fh;
 
 pub fn mount_and_run(what: &OsStr, whence: &OsStr) -> Result<()> {
     let filesystem = ext4fs::Ext4FS::new(what.to_os_string())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 mod block_device;
 mod ext4fs;
 mod fh;
+mod mappe;
 
 pub fn mount_and_run(what: &OsStr, whence: &OsStr) -> Result<()> {
     let filesystem = ext4fs::Ext4FS::new(what.to_os_string())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 
 use anyhow::Result;
 
+mod block_device;
 mod ext4fs;
 
 pub fn mount_and_run(what: &OsStr, whence: &OsStr) -> Result<()> {

--- a/src/mappe.rs
+++ b/src/mappe.rs
@@ -1,0 +1,26 @@
+use std::convert::TryFrom;
+
+use ext4::FileType as ExtFileType;
+use ext4::Time;
+use fuse_mt::FileType;
+use time::Timespec;
+
+pub fn timespec(time: Time) -> Timespec {
+    Timespec::new(
+        i64::from(time.epoch_secs),
+        time.nanos.and_then(|v| i32::try_from(v).ok()).unwrap_or(0),
+    )
+}
+
+pub fn map_kind(file_type: ExtFileType) -> FileType {
+    match file_type {
+        ExtFileType::RegularFile => FileType::RegularFile,
+        ExtFileType::SymbolicLink => FileType::Symlink,
+        ExtFileType::CharacterDevice => FileType::CharDevice,
+        ExtFileType::BlockDevice => FileType::BlockDevice,
+        ExtFileType::Directory => FileType::Directory,
+        // TODO: maybe?
+        ExtFileType::Fifo => FileType::NamedPipe,
+        ExtFileType::Socket => FileType::Socket,
+    }
+}

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,8 +1,5 @@
-use std::convert::TryFrom;
-use std::ffi::OsString;
-use std::ffi::{CString, OsStr};
+use std::ffi::CString;
 use std::fs;
-use std::path::Path;
 use std::thread;
 use std::time::Duration;
 


### PR DESCRIPTION
Fill out some methods.

### Screenshots

```
faux@astoria:~/clone/fuse-ext4-rs% ls -al mnt                 
total 0
drwxr-xr-x 6 root root     1024 Jun  6  2017 .
drwxrwxr-x 1 faux faux      196 Jan 29 07:28 ..
drwxr-xr-x 4 root root     1024 Jun  6  2017 a
brw-r--r-- 1 root root     0, 0 Jun  6  2017 block-device
crw-r--r-- 1 root root     0, 0 Jun  6  2017 char-device
drwxr-xr-x 2 root root     1024 Jun  6  2017 empty-directory
-rw-r--r-- 1 root root        0 Jun  6  2017 empty-file
crw-r--r-- 1 root root     0, 0 Jun  6  2017 extremely-major-device
crw-r--r-- 1 root root     0, 0 Jun  6  2017 extremely-minor-device
prw-r--r-- 1 root root        0 Jun  6  2017 fifo-file
-rw-r--r-- 2 root root 10485760 Jun  6  2017 hardlink-file
drwxr-xr-x 3 root root     1024 Jun  6  2017 home
drwx------ 2 root root    12288 Jun  6  2017 lost+found
-rw-r--r-- 1 root root        0 Jun  6  2017 multiple-xattrs
lrwxrwxrwx 1 root root        8 Jun  6  2017 nonsense-symlink-file -> nonsense
-rw-r--r-- 1 root root        0 Jun  6  2017 single-xattr
srwxr-xr-x 1 root root        0 Jun  6  2017 sock-file
-rw-r--r-- 2 root root 10485760 Jun  6  2017 sparse-file
```

```
faux@astoria:~/clone/fuse-ext4-rs% find mnt                   
mnt
mnt/lost+found
mnt/empty-file
mnt/empty-directory
mnt/a
mnt/a/deeply
mnt/a/deeply/nested
mnt/a/deeply/nested/directory
mnt/a/multiple
mnt/a/multiple/entry
mnt/a/multiple/entry/directory
mnt/home
mnt/home/faux
mnt/home/faux/hello.txt
mnt/sparse-file
mnt/fifo-file
mnt/sock-file
mnt/nonsense-symlink-file
mnt/hardlink-file
mnt/char-device
mnt/block-device
mnt/extremely-minor-device
mnt/extremely-major-device
mnt/single-xattr
mnt/multiple-xattrs
```

```
faux@astoria:~/clone/fuse-ext4-rs% cat mnt/home/faux/hello.txt
Hello, world!
```